### PR TITLE
Update kotlin version to 1.8.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ import java.util.function.BinaryOperator
 
 buildscript {
     ext{
-        kotlin_version = '1.6.10'
+        kotlin_version = '1.8.21'
     }
     repositories {
         google()
@@ -23,7 +23,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
@@ -33,7 +33,7 @@ buildscript {
 }
 
 plugins {
-    id "kotlinx-serialization" version "1.6.10" apply true
+    id "kotlinx-serialization" version "1.8.21" apply true
     id "io.gitlab.arturbosch.detekt" version "1.0.0-RC16"
     id "org.jetbrains.dokka" version "1.7.10"
     id 'org.ajoberstar.grgit' version '5.0.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/uf-client-service/build.gradle
+++ b/uf-client-service/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdk 31
     defaultConfig {
         applicationId "com.kynetics.uf.service"
         minSdkVersion 19

--- a/uf-client-service/uf-client-service-api/build.gradle
+++ b/uf-client-service/uf-client-service-api/build.gradle
@@ -16,7 +16,7 @@ group='com.kynetics.uf.android.api'
 version versionFromGit(project)
 
 android {
-    compileSdkVersion 30
+    compileSdk 31
     defaultConfig {
         minSdkVersion 19
         //noinspection ExpiredTargetSdkVersion


### PR DESCRIPTION
Update several build components:
- Update kotlin version to 1.8.21
- Change the compile sdk version to 31
- Update android gradle plugin to 7.4.2
- Update gradle version to 7.5

The kotlin update in particular should fix a syntax highlighting issue experienced in Android Studio when using the Update Service API from Java: https://youtrack.jetbrains.com/issue/KTIJ-19699/IDE-False-positive-type-mismatch-in-Java-code-for-Kotlin-nested-class-non-direct-inheritor-from-external-library