### PR TITLE
Ignore ufConf.conf when using Api

### DIFF
--- a/uf-client-service/src/main/kotlin/com/kynetics/uf/android/communication/impl/AbstractCommunicationApi.kt
+++ b/uf-client-service/src/main/kotlin/com/kynetics/uf/android/communication/impl/AbstractCommunicationApi.kt
@@ -81,7 +81,7 @@ abstract class AbstractCommunicationApi(
         val currentConf = configurationHandler.getCurrentConfiguration()
 
         if (currentConf != newConf.toUFServiceConfiguration()) {
-            configurationHandler.saveServiceConfigurationToSharedPreferences(newConf.toUFServiceConfiguration())
+            configurationHandler.saveServiceConfigurationToSharedPreferences(newConf.toUFServiceConfiguration(), true)
             Log.i(tag, "configuration updated")
         } else {
             Log.i(tag, "new configuration equals to current configuration")

--- a/uf-client-service/src/main/kotlin/com/kynetics/uf/android/communication/impl/CommunicationApiV1_1Impl.kt
+++ b/uf-client-service/src/main/kotlin/com/kynetics/uf/android/communication/impl/CommunicationApiV1_1Impl.kt
@@ -36,7 +36,7 @@ open class CommunicationApiV1_1Impl(configurationHandler: ConfigurationHandler,
         val currentConf = configurationHandler.getCurrentConfiguration()
 
         if (currentConf != newConf) {
-            configurationHandler.saveServiceConfigurationToSharedPreferences(newConf)
+            configurationHandler.saveServiceConfigurationToSharedPreferences(newConf, true)
             Log.i(TAG, "configuration updated")
         } else {
             Log.i(TAG, "new configuration equals to current configuration")

--- a/uf-client-service/src/main/kotlin/com/kynetics/uf/android/configuration/ConfigurationFileLoader.kt
+++ b/uf-client-service/src/main/kotlin/com/kynetics/uf/android/configuration/ConfigurationFileLoader.kt
@@ -28,7 +28,7 @@ class ConfigurationFileLoader(private val sh: SharedPreferences, private val con
     private val map: MutableMap<String, String> = HashMap()
     val newFileConfiguration: UFServiceConfigurationV2?
         get() {
-            if (!configurationFileFound() || !isNewConfigurationFile) {
+            if (!configurationFileFound() || isServiceConfiguredWithApi || !isNewConfigurationFile) {
                 return null
             }
 
@@ -83,6 +83,12 @@ class ConfigurationFileLoader(private val sh: SharedPreferences, private val con
                 e.printStackTrace()
             }
             return false
+        }
+
+    private val isServiceConfiguredWithApi: Boolean
+        get() {
+            val keys = SharedPreferencesKeys.getInstance(context)
+            return sh.getBoolean(keys.sharedPreferencesConfigurationLoadedFromApi, false)
         }
 
     private fun configurationFileFound(): Boolean {

--- a/uf-client-service/src/main/kotlin/com/kynetics/uf/android/configuration/ConfigurationHandler.kt
+++ b/uf-client-service/src/main/kotlin/com/kynetics/uf/android/configuration/ConfigurationHandler.kt
@@ -62,7 +62,8 @@ data class ConfigurationHandler (
     }
 
     fun saveServiceConfigurationToSharedPreferences(
-        configuration: UFServiceConfigurationV2?
+        configuration: UFServiceConfigurationV2?,
+        configurationLoadedFromApi: Boolean = false
     ) {
         if (configuration == null) {
             return
@@ -71,6 +72,9 @@ data class ConfigurationHandler (
             if(isTargetTokenReceivedFromServerOld(configuration)){
                 remove(keys.sharedPreferencesTargetTokenReceivedFromServer)
             }
+
+            putBoolean(keys.sharedPreferencesConfigurationLoadedFromApi, configurationLoadedFromApi)
+
             putString(keys.sharedPreferencesControllerIdKey, configuration.controllerId)
             putString(keys.sharedPreferencesTenantKey, configuration.tenant)
             putString(keys.sharedPreferencesServerUrlKey, configuration.url)

--- a/uf-client-service/src/main/kotlin/com/kynetics/uf/android/configuration/SharedPreferencesKeys.kt
+++ b/uf-client-service/src/main/kotlin/com/kynetics/uf/android/configuration/SharedPreferencesKeys.kt
@@ -27,6 +27,7 @@ class SharedPreferencesKeys private constructor(context: Context){
     val sharedPreferencesTimeWindowsDuration:String = context.getString(R.string.shared_preferences_time_windows_duration_key)
     val sharedPreferencesTargetAttributesFromConfiguration:String = context.getString(R.string.shared_preferences_args_key)
     val sharedPreferencesAddTargetAttributes:String = context.getString(R.string.shared_preferences_add_target_attributes_key)
+    val sharedPreferencesConfigurationLoadedFromApi:String = context.getString(R.string.shared_preferences_configuration_loaded_from_api)
 
     companion object{
         private var instance: SharedPreferencesKeys? = null

--- a/uf-client-service/src/main/res/values/strings.xml
+++ b/uf-client-service/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="shared_preferences_is_update_factory_server_type_key" translatable="false">IS_UF_SERVER_TYPE_KEY</string>
     <string name="shared_preferences_target_token_received_from_server_key" translatable="false">TARGET_TOKEN_SERVER_KEY</string>
     <string name="shared_preferences_target_token_received_from_server_title" translatable="false">Target token received from server</string>
+    <string name="shared_preferences_configuration_loaded_from_api" translatable="false">CONFIGURATION_LOADED_FROM_API</string>
 
 
     <string name="pref_title_add_friends_to_messages">Add friends to messages</string>


### PR DESCRIPTION
Adds a feature to ignore the config file after using api for configuration 
The ufConf.conf file is for a quick & easy setup of the service.
The usage of this file should be prevented after using the api to config