### PR TITLE
Exclude the os-mock module if Jitpack is building

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -17,4 +17,5 @@ pluginManagement {
     }
 }
 include ':uf-client-service', ':uf-client-service:uf-client-service-api', ':uf-ddiclient'
-include ':os-mock'
+if (!System.env.JITPACK)
+    include ':os-mock'

--- a/uf-client-service/build.gradle
+++ b/uf-client-service/build.gradle
@@ -111,7 +111,8 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation project(":uf-ddiclient")
-    compileOnly project(":os-mock")
+    if (!System.env.JITPACK)
+        compileOnly(project(":os-mock"))
     implementation 'de.psdev.slf4j-android-logger:slf4j-android-logger:1.0.5'
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
     implementation "com.google.android.material:material:1.0.0"


### PR DESCRIPTION
Apparently when the Jitpack tries to build the library, it includes the os-mock module inside the library, where it introduces some crashes Now the os-mock module is only included if it's not in Jitpack environment.