### PR TITLE
Add apk file validation check

### DIFF
--- a/uf-client-service/src/main/kotlin/com/kynetics/uf/android/update/application/ApkInstaller.kt
+++ b/uf-client-service/src/main/kotlin/com/kynetics/uf/android/update/application/ApkInstaller.kt
@@ -42,6 +42,12 @@ object ApkInstaller : Installer<Unit> {
                 currentUpdateState.addErrorToRepor(errorMessage)
             }
 
+            getPackageFromApk(context, apk.absolutePath) == null -> {
+                val errorMessage = "Apk file is invalid"
+                Log.w(ApkUpdater.TAG, errorMessage)
+                currentUpdateState.addErrorToRepor(errorMessage)
+            }
+
             !verifySharedUserId(context, apk.absolutePath) -> {
                 val errorMessage = "Application was already installed with a different sharedUserId"
                 Log.w(ApkUpdater.TAG, errorMessage)


### PR DESCRIPTION
When an invalid apk file is sent to the device, the server reports "Application was already installed with a different sharedUserId" Added a check for validating the apk file.