### PR TITLE
Improve logs

### DIFF
--- a/uf-client-service/src/main/kotlin/com/kynetics/uf/android/communication/messenger/MessageHandler.kt
+++ b/uf-client-service/src/main/kotlin/com/kynetics/uf/android/communication/messenger/MessageHandler.kt
@@ -11,7 +11,6 @@
 
 package com.kynetics.uf.android.communication.messenger
 
-import android.util.Log
 import com.kynetics.uf.android.api.UFServiceMessage
 import com.kynetics.uf.android.api.v1.UFServiceMessageV1
 import com.kynetics.uf.android.converter.toUFMessage
@@ -94,7 +93,7 @@ data class V1x(
 ) : MessageHandler<String?> {
 
     override fun onMessage(msg: MessageListener.Message): MessageHandler<String?>? {
-        return onAndroidMessage(msg.toUFMessage())
+        return mapMessage(msg.toUFMessage())
     }
 
     override fun onConfigurationError(details: List<String>): MessageHandler<String?> {
@@ -103,7 +102,10 @@ data class V1x(
     }
 
     override fun onAndroidMessage(msg: UFServiceMessageV1): MessageHandler<String?>? {
-        Log.i("v1", "onAndroidMessage $msg")
+        return mapMessage(msg)
+    }
+
+    private fun mapMessage(msg: UFServiceMessageV1): MessageHandler<String?>? {
         return when (val finalMsg = msgMapper(msg)) {
             is UFServiceMessageV1.Event -> {
                 copy(currentMessage = finalMsg.toJson())
@@ -126,9 +128,13 @@ object MessageHandlerFactory{
         msgMapper = { msg:UFServiceMessageV1 ->
             when(msg){
                 is UFServiceMessageV1.State.WaitingUpdateWindow -> UFServiceMessageV1.State.WaitingUpdateAuthorization
-                is UFServiceMessageV1.Event.Stopped, is UFServiceMessageV1.Event.Started, is UFServiceMessageV1.Event.CantBeStopped, is UFServiceMessageV1.Event.ConfigurationUpdated, is UFServiceMessageV1.Event.NewTargetTokenReceived -> null
+                is UFServiceMessageV1.Event.Stopped,
+                is UFServiceMessageV1.Event.Started,
+                is UFServiceMessageV1.Event.CantBeStopped,
+                is UFServiceMessageV1.Event.ConfigurationUpdated,
+                is UFServiceMessageV1.Event.NewTargetTokenReceived -> null
                 else -> msg
-            }.also { newMsg -> Log.i("v1", "mapping $msg to $newMsg") }
+            }
         }
     )
 
@@ -136,9 +142,13 @@ object MessageHandlerFactory{
     fun newV1_1():V1x = V1x(
         msgMapper = { msg:UFServiceMessageV1 ->
             when(msg){
-                is UFServiceMessageV1.Event.Stopped, is UFServiceMessageV1.Event.Started, is UFServiceMessageV1.Event.CantBeStopped, is UFServiceMessageV1.Event.ConfigurationUpdated, is UFServiceMessageV1.Event.NewTargetTokenReceived -> null
+                is UFServiceMessageV1.Event.Stopped,
+                is UFServiceMessageV1.Event.Started,
+                is UFServiceMessageV1.Event.CantBeStopped,
+                is UFServiceMessageV1.Event.ConfigurationUpdated,
+                is UFServiceMessageV1.Event.NewTargetTokenReceived -> null
                 else -> msg
-            }.also { newMsg -> Log.i("v1.1", "mapping $msg to $newMsg") }
+            }
         }
     )
 

--- a/uf-client-service/src/main/kotlin/com/kynetics/uf/android/configuration/AndroidMessageListener.kt
+++ b/uf-client-service/src/main/kotlin/com/kynetics/uf/android/configuration/AndroidMessageListener.kt
@@ -25,6 +25,7 @@ class AndroidMessageListener(private val service: UpdateFactoryService) : Messag
     private val mNotificationManager = service.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
     override fun onMessage(message: MessageListener.Message) {
+        Log.i(TAG, "Message received from Hara: $message")
         when (message) {
             is MessageListener.Message.Event.UpdateFinished,
             is MessageListener.Message.State.CancellingUpdate -> {
@@ -39,7 +40,6 @@ class AndroidMessageListener(private val service: UpdateFactoryService) : Messag
         MessengerHandler.notifyHaraMessage(message)
 
         mNotificationManager.notify(UpdateFactoryService.NOTIFICATION_ID, service.getNotification(message.toString()))
-        Log.i(TAG, message.toString())
     }
 
     companion object {


### PR DESCRIPTION
Remove redundant and unnecessary logs

Old logs:
```
2023-11-29 13:52:26.962 5644  Update Fa...y Client com...ics.uf.service  I  Execute ping calls to the server... [ConnectionManager:onPing:192] Thread[DefaultDispatcher-worker-8,5,main]
2023-11-29 13:52:26.964 5644  v1                   com...ics.uf.service  I  onAndroidMessage Polling
2023-11-29 13:52:26.964 5644  v1                   com...ics.uf.service  I  mapping Polling to Polling
2023-11-29 13:52:26.964 5644  v1                   com...ics.uf.service  I  onAndroidMessage Polling
2023-11-29 13:52:26.964 5644  v1.1                 com...ics.uf.service  I  mapping Polling to Polling
2023-11-29 13:52:26.965 5644  v1                   com...ics.uf.service  I  onAndroidMessage Polling
2023-11-29 13:52:26.968 5644  AndroidMe...Listener com...ics.uf.service  I  Polling
2023-11-29 13:50:21.280 5644  Update Fa...y Client com...ics.uf.service  I  BaseResource not changed [::0] Thread[DefaultDispatcher-worker-3,5,main]
```

New logs:
```
2023-12-07 11:50:00.979 1812  Update Fa...y Client com...ics.uf.service  I  Execute ping calls to the server... [ConnectionManager:onPing:188] Thread[DefaultDispatcher-worker-1,5,main]
2023-12-07 11:50:00.980 1812  AndroidMe...Listener com...ics.uf.service  I  Message received from Hara: Polling
2023-12-07 11:50:01.207 1812  Update Fa...y Client com...ics.uf.service  I  BaseResource not changed [::0] Thread[DefaultDispatcher-worker-1,5,main]
```