### PR TITLE
Implement double http request

### DIFF
--- a/uf-ddiclient/build.gradle
+++ b/uf-ddiclient/build.gradle
@@ -20,7 +20,7 @@ java {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    api("com.github.eclipse:hara-ddiclient:86e905cfdfafdd3ed6cc334ed225ded4162bb2ec"){
+    api("com.github.eclipse:hara-ddiclient:f902a39adc"){
         exclude group: "org.slf4j", module: "slf4j-simple"
     }
     implementation "com.squareup.okhttp3:okhttp:4.9.3"

--- a/uf-ddiclient/src/main/java/com/kynetics/uf/ddiclient/HaraClientFactory.kt
+++ b/uf-ddiclient/src/main/java/com/kynetics/uf/ddiclient/HaraClientFactory.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2017-2023  Kynetics  LLC
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -81,11 +81,11 @@ object HaraClientFactory {
     private fun getOkHttpBuilder(listener:TargetTokenFoundListener,clientData:HaraClientData): OkHttpClient.Builder{
         val authentications = HashSet<Authentication>()
         with(clientData) {
-            if (gatewayToken != null) {
-                authentications.add(Authentication.newInstance(Authentication.AuthenticationType.GATEWAY_TOKEN_AUTHENTICATION, gatewayToken!!))
-            }
-            if (targetToken != null) {
+            if (!targetToken.isNullOrBlank()) {
                 authentications.add(Authentication.newInstance(Authentication.AuthenticationType.TARGET_TOKEN_AUTHENTICATION, targetToken!!))
+            }
+            if (!gatewayToken.isNullOrBlank()) {
+                authentications.add(Authentication.newInstance(Authentication.AuthenticationType.GATEWAY_TOKEN_AUTHENTICATION, gatewayToken!!))
             }
         }
         val authentication=UpdateFactoryAuthenticationRequestInterceptor(authentications,listener)


### PR DESCRIPTION
In this commit, the behavior of the OkHttp client is modified. Instead of setting two headers in a single request, it now sends the first request with the target token. If that fails, it retries the request with the gateway token.