### PR TITLE
Fix immediate authorization respond getting ignored

### DIFF
--- a/uf-client-service/src/main/kotlin/com/kynetics/uf/android/configuration/AndroidDeploymentPermitProvider.kt
+++ b/uf-client-service/src/main/kotlin/com/kynetics/uf/android/configuration/AndroidDeploymentPermitProvider.kt
@@ -35,14 +35,6 @@ interface AndroidDeploymentPermitProvider : DeploymentPermitProvider {
                 private var authResponse = CompletableDeferred<Boolean>()
 
                 private fun allowedAsync(auth: UpdateFactoryService.Companion.AuthorizationType): Deferred<Boolean> {
-                    if (configurationHandler.apiModeIsEnabled()) {
-                        MessengerHandler.sendBroadcastMessage(Communication.V1.Out.AuthorizationRequest.ID, auth.name)
-                    } else {
-                        showAuthorizationDialog(auth)
-                        mNotificationManager.notify(UpdateFactoryService.AUTHORIZATION_GRANT_NOTIFICATION_ID,
-                            service.getNotification(auth.event, true))
-                    }
-
                     authResponse.complete(false)
                     authResponse = CompletableDeferred()
                     authResponse.invokeOnCompletion {
@@ -51,6 +43,17 @@ interface AndroidDeploymentPermitProvider : DeploymentPermitProvider {
                         } else {
                             MessengerHandler.onAction(auth.toActionOnDenied)
                         }
+                    }
+
+                    if (configurationHandler.apiModeIsEnabled()) {
+                        MessengerHandler.sendBroadcastMessage(
+                            Communication.V1.Out.AuthorizationRequest.ID,
+                            auth.name)
+                    } else {
+                        showAuthorizationDialog(auth)
+                        mNotificationManager.notify(
+                            UpdateFactoryService.AUTHORIZATION_GRANT_NOTIFICATION_ID,
+                            service.getNotification(auth.event, true))
                     }
 
                     return authResponse

--- a/uf-ddiclient/build.gradle
+++ b/uf-ddiclient/build.gradle
@@ -20,7 +20,7 @@ java {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    api("com.github.eclipse-hara:hara-ddiclient:e0969c948f"){
+    api("com.github.eclipse-hara:hara-ddiclient:bcc024624c"){
         exclude group: "org.slf4j", module: "slf4j-simple"
     }
     implementation "com.squareup.okhttp3:okhttp:4.9.3"


### PR DESCRIPTION
This commit addresses an issue where the client sends an immediate
 authorization response upon receiving the authorization request, which
 might get ignored, causing the client to be stuck waiting for the
 authorization response.
This commit will change the behavior of DeploymentPermitProvider to send the authorization event/state after
waiting for the authorization response message.

UF-870
Signed-off-by: Saeed Rezaee <saeed.rezaee@kynetics.it>