### PR TITLE
Fix crash when accessing the EncryptedSharedPreferences

### DIFF
--- a/uf-client-service/src/main/kotlin/com/kynetics/uf/android/content/EncryptedSharedPreferences.kt
+++ b/uf-client-service/src/main/kotlin/com/kynetics/uf/android/content/EncryptedSharedPreferences.kt
@@ -12,28 +12,85 @@ package com.kynetics.uf.android.content
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
+import java.io.File
+import java.security.KeyStore
 
 object EncryptedSharedPreferences {
 
     private const val SHARED_PREFERENCE_FILE_NAME = "UF_SECURE_SHARED_FILE"
+    private const val DEFAULT_MASTER_KEY_ALIAS = "_androidx_security_master_key_"
+    private const val KEYSTORE_PROVIDER = "AndroidKeyStore"
+    private val TAG = EncryptedSharedPreferences::class.java.simpleName
+
+    private val masterKeyAlias: String
+        get() = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
 
     fun get(context: Context): SharedPreferences {
-        return EncryptedSharedPreferences
+        return openKeystoreWithDefaultMasterKey(context)
+    }
+
+    private fun openKeystoreWithDefaultMasterKey(context: Context): SharedPreferences {
+        return getSharedPreferencesOrNull(context) ?: run {
+
+            Log.d(TAG, "Cannot retrieve encrypted preferences. Deleting and recreating.")
+            resetEncryptedSharedPreferences(context)
+            
+            //Creating the shared preferences again
+            getSharedPreferencesOrNull(context)
+        } ?: throw IllegalStateException("Cannot create encrypted shared preferences")
+    }
+
+    private fun getSharedPreferencesOrNull(context: Context): SharedPreferences? {
+        return try {
+            EncryptedSharedPreferences
                 .create(
-                        SHARED_PREFERENCE_FILE_NAME,
-                        masterKeyAlias(),
-                        context,
-                        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+                    SHARED_PREFERENCE_FILE_NAME,
+                    masterKeyAlias,
+                    context,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
                 )
+        } catch (e: Exception) {
+            Log.w(TAG, "Unable to create encrypted shared preferences", e)
+            null
+        }
     }
 
-
-    private fun masterKeyAlias(): String {
-        val keyGenParameterSpec = MasterKeys.AES256_GCM_SPEC
-        return MasterKeys.getOrCreate(keyGenParameterSpec)
+    private fun resetEncryptedSharedPreferences(context: Context) {
+        deleteMasterKey()
+        clearEncryptedSharedPreferences(context)
+        deleteEncryptedSharedPreferencesFile(context)
     }
 
+    private fun deleteMasterKey() {
+        try {
+            val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER)
+            keyStore.load(null)
+            keyStore.deleteEntry(DEFAULT_MASTER_KEY_ALIAS)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to delete MasterKey", e)
+        }
+    }
+
+    private fun clearEncryptedSharedPreferences(context: Context) {
+        runCatching {
+            context.getSharedPreferences(SHARED_PREFERENCE_FILE_NAME, Context.MODE_PRIVATE)
+                .edit().clear().apply()
+        }.onFailure {
+            Log.w(TAG, "Failed to clear the encrypted shared preferences", it)
+        }
+    }
+
+    private fun deleteEncryptedSharedPreferencesFile(context: Context) {
+        runCatching {
+            val deleted = File(context.applicationInfo.dataDir,
+                "shared_prefs/$SHARED_PREFERENCE_FILE_NAME.xml").delete()
+            if (!deleted) {
+                Log.w(TAG, "Failed to delete the encrypted shared preferences file")
+            }
+        }
+    }
 }


### PR DESCRIPTION
This is a known bug reported to Google issue tracker: 
https://issuetracker.google.com/issues/176215143
The current workaround involves clearing the old shared preferences and the generated keystore, then recreating the shared preferences file whenever the system fails to access the encrypted shared preferences.
Another preventive measure is to disable application backup in the Android manifest file. (Not tested)

This fix requires testing the uf-service updates from older versions.
✅ I currently tested v1.6.0 -> v1.6.0-2-gabd8621(This fix)
⬜ Upgrading the uf-service through an OTA also required.

UF-880